### PR TITLE
Correct the route for study chapters

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -340,7 +340,7 @@ export default {
         })
       })
 
-      router.add('study/:id/chapter/:chapterId', ({ params }) => {
+      router.add('study/:id/:chapterId', ({ params }) => {
         import('./ui/study/study').then(m => {
           onRouteMatch(m.default, params)
         })


### PR DESCRIPTION
Chapter links from the website don't have /chapter/ in the URL. The app exports them correctly but does not recognize them.